### PR TITLE
Implement role CRUD and extend user model

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,9 @@
 const express = require('express');
 const app = express();
 const userRoutes = require('./routes/userRoutes');
+const roleRoutes = require('./routes/roleRoutes');
 app.use(express.json());
 app.use('/api/users', userRoutes);
+app.use('/api/roles', roleRoutes);
 
 module.exports = app;

--- a/src/controllers/roleController.js
+++ b/src/controllers/roleController.js
@@ -1,0 +1,34 @@
+const roleService = require('../services/roleService');
+const { validationResult } = require('express-validator');
+
+exports.listRoles = async (req, res) => {
+  const roles = await roleService.listRoles();
+  res.json(roles);
+};
+
+exports.getRole = async (req, res) => {
+  const role = await roleService.getRole(req.params.id);
+  if (!role) return res.status(404).json({ message: 'Rol no encontrado' });
+  res.json(role);
+};
+
+exports.createRole = async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+  const id = await roleService.createRole(req.body);
+  res.status(201).json({ id });
+};
+
+exports.updateRole = async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+  const affected = await roleService.updateRole(req.params.id, req.body);
+  if (!affected) return res.status(404).json({ message: 'Rol no encontrado' });
+  res.json({ message: 'Rol actualizado' });
+};
+
+exports.deleteRole = async (req, res) => {
+  const affected = await roleService.deleteRole(req.params.id);
+  if (!affected) return res.status(404).json({ message: 'Rol no encontrado' });
+  res.json({ message: 'Rol eliminado' });
+};

--- a/src/models/roleModel.js
+++ b/src/models/roleModel.js
@@ -1,0 +1,35 @@
+const pool = require('../config/db');
+
+exports.getAll = async () => {
+  const [rows] = await pool.query('SELECT id, name, description, is_active FROM roles WHERE is_active = 1');
+  return rows;
+};
+
+exports.getById = async (id) => {
+  const [rows] = await pool.query('SELECT id, name, description, is_active FROM roles WHERE id = ? AND is_active = 1', [id]);
+  return rows[0];
+};
+
+exports.create = async ({ name, description }) => {
+  const [result] = await pool.query(
+    'INSERT INTO roles (name, description, is_active) VALUES (?, ?, 1)',
+    [name, description]
+  );
+  return result.insertId;
+};
+
+exports.update = async (id, { name, description }) => {
+  const [result] = await pool.query(
+    'UPDATE roles SET name=?, description=? WHERE id=? AND is_active = 1',
+    [name, description, id]
+  );
+  return result.affectedRows;
+};
+
+exports.softDelete = async (id) => {
+  const [result] = await pool.query(
+    'UPDATE roles SET is_active=0 WHERE id=?',
+    [id]
+  );
+  return result.affectedRows;
+};

--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -2,12 +2,12 @@ const pool = require('../config/db');
 
 
 exports.getAll = async () => {
-  const [rows] = await pool.query('SELECT id, username, email, role_id, is_active, created_at FROM users WHERE is_active = 1');
+  const [rows] = await pool.query('SELECT id, username, email, points, rut, role_id, is_active, created_at FROM users WHERE is_active = 1');
   return rows;
 };
 
 exports.getById = async (id) => {
-  const [rows] = await pool.query('SELECT id, username, email, role_id, is_active, created_at FROM users WHERE id = ? AND is_active = 1', [id]);
+  const [rows] = await pool.query('SELECT id, username, email, points, rut, role_id, is_active, created_at FROM users WHERE id = ? AND is_active = 1', [id]);
   return rows[0];
 };
 
@@ -17,19 +17,19 @@ exports.getByEmail = async (email) => {
 };
 
 exports.create = async (user) => {
-  const { username, email, password_hash, role_id } = user;
+  const { username, email, password_hash, role_id, rut, points } = user;
   const [result] = await pool.query(
-    'INSERT INTO users (username, email, password_hash, role_id, is_active) VALUES (?, ?, ?, ?, 1)',
-    [username, email, password_hash, role_id]
+    'INSERT INTO users (username, email, password_hash, rut, role_id, points, is_active) VALUES (?, ?, ?, ?, ?, ?, 1)',
+    [username, email, password_hash, rut, role_id, points || 0]
   );
   return result.insertId;
 };
 
 exports.update = async (id, user) => {
-  const { username, email, role_id } = user;
+  const { username, email, role_id, rut, points } = user;
   const [result] = await pool.query(
-    'UPDATE users SET username=?, email=?, role_id=? WHERE id=? AND is_active = 1',
-    [username, email, role_id, id]
+    'UPDATE users SET username=?, email=?, rut=?, role_id=?, points=? WHERE id=? AND is_active = 1',
+    [username, email, rut, role_id, points, id]
   );
   return result.affectedRows;
 };

--- a/src/routes/roleRoutes.js
+++ b/src/routes/roleRoutes.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const router = express.Router();
+const roleController = require('../controllers/roleController');
+const { createRoleValidation, updateRoleValidation } = require('../validations/roleValidation');
+const authenticateToken = require('../middlewares/auth');
+const authorizeRoles = require('../middlewares/roles');
+
+router.get('/', authenticateToken, authorizeRoles('admin'), roleController.listRoles);
+router.get('/:id', authenticateToken, authorizeRoles('admin'), roleController.getRole);
+router.post('/', authenticateToken, authorizeRoles('admin'), createRoleValidation, roleController.createRole);
+router.put('/:id', authenticateToken, authorizeRoles('admin'), updateRoleValidation, roleController.updateRole);
+router.delete('/:id', authenticateToken, authorizeRoles('admin'), roleController.deleteRole);
+
+module.exports = router;

--- a/src/services/roleService.js
+++ b/src/services/roleService.js
@@ -1,0 +1,15 @@
+const roleModel = require('../models/roleModel');
+
+exports.listRoles = async () => roleModel.getAll();
+
+exports.getRole = async (id) => roleModel.getById(id);
+
+exports.createRole = async ({ name, description }) => {
+  return roleModel.create({ name, description });
+};
+
+exports.updateRole = async (id, { name, description }) => {
+  return roleModel.update(id, { name, description });
+};
+
+exports.deleteRole = async (id) => roleModel.softDelete(id);

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -5,13 +5,13 @@ exports.listUsers = async () => userModel.getAll();
 
 exports.getUser = async (id) => userModel.getById(id);
 
-exports.createUser = async ({ username, email, password, role_id }) => {
+exports.createUser = async ({ username, email, password, role_id, rut, points }) => {
   const password_hash = await bcrypt.hash(password, 10);
-  return userModel.create({ username, email, password_hash, role_id });
+  return userModel.create({ username, email, password_hash, role_id, rut, points });
 };
 
-exports.updateUser = async (id, { username, email, role_id }) => {
-  return userModel.update(id, { username, email, role_id });
+exports.updateUser = async (id, { username, email, role_id, rut, points }) => {
+  return userModel.update(id, { username, email, role_id, rut, points });
 };
 
 exports.deleteUser = async (id) => userModel.softDelete(id);

--- a/src/validations/roleValidation.js
+++ b/src/validations/roleValidation.js
@@ -1,0 +1,11 @@
+const { body } = require('express-validator');
+
+exports.createRoleValidation = [
+  body('name').isString().notEmpty(),
+  body('description').optional().isString()
+];
+
+exports.updateRoleValidation = [
+  body('name').optional().isString().notEmpty(),
+  body('description').optional().isString()
+];

--- a/src/validations/userValidation.js
+++ b/src/validations/userValidation.js
@@ -4,11 +4,15 @@ exports.createUserValidation = [
   body('username').isString().isLength({ min: 3 }),
   body('email').isEmail(),
   body('password').isLength({ min: 6 }),
-  body('role_id').notEmpty()
+  body('role_id').notEmpty(),
+  body('rut').optional().isString().isLength({ min: 3 }),
+  body('points').optional().isInt()
 ];
 
 exports.updateUserValidation = [
   body('username').optional().isString().isLength({ min: 3 }),
   body('email').optional().isEmail(),
-  body('role_id').optional().notEmpty()
+  body('role_id').optional().notEmpty(),
+  body('rut').optional().isString().isLength({ min: 3 }),
+  body('points').optional().isInt()
 ];


### PR DESCRIPTION
## Summary
- add route registration for `roles`
- extend `users` schema with points and rut fields
- implement CRUD logic for roles
- update user service/model/validation to support new fields

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685db4262a70832fa29849ce5b267325